### PR TITLE
fix: add --change-asset-href option to create-item command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ number as needed.
 
 ## [Unreleased]
 
+## [0.2.3]
+
+### Fixed
+
+- Add `--change-asset-href` as an optional argument to the `create-item` command
+
 ## [0.2.2]
 
 ### Fixed
@@ -33,7 +39,9 @@ number as needed.
 
 - STAC metadata capabilities for the raster assets ([#1](https://github.com/stactools-packages/global-mangrove-watch/pull/1))
 
-[Unreleased]: <https://github.com/stactools-packages/global-mangrove-watch/compare/0.2.0...main>
+[Unreleased]: <https://github.com/stactools-packages/global-mangrove-watch/compare/0.2.3...main>
+[0.2.3]: <https://github.com/stactools-packages/global-mangrove-watch/compare/0.2.2...0.2.3>
+[0.2.2]: <https://github.com/stactools-packages/global-mangrove-watch/compare/0.2.1...0.2.2>
 [0.2.1]: <https://github.com/stactools-packages/global-mangrove-watch/compare/0.2.0...0.2.1>
 [0.2.0]: <https://github.com/stactools-packages/global-mangrove-watch/compare/0.1.0...0.2.0>
 [0.1.0]: <https://github.com/stactools-packages/global-mangrove-watch/tree/0.1.0>

--- a/README.md
+++ b/README.md
@@ -40,16 +40,22 @@ pip install stactools-global-mangrove-watch
 Create a collection json:
 
 ```shell
-stac global-mangrove-watch create-collection {destination}
+stac globalmangrovewatch create-collection {destination}
 ```
 
 Create an item json:
 
 ```shell
-stac global-mangrove-watch create-item {cog_asset_href} {destination}
+stac globalmangrovewatch create-item {cog_asset_href} {destination}
 ```
 
-Use `stac global-mangrove-watch --help` to see all subcommands and options.
+Create an item json with the change asset added
+
+```shell
+stac globalmangrovewatch create-item {cog_asset_href} {destination} --change-asset-href {change_asset_href}
+```
+
+Use `stac globalmangrovewatch --help` to see all subcommands and options.
 
 ## Contributing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stactools-global-mangrove-watch"
-version = "0.2.2"
+version = "0.2.3"
 description = "A stactools package for the Global Mangrove Watch dataset"
 readme = "README.md"
 authors = [{ name = "Henry Rodman", email = "henry@developmentseed.org" }]

--- a/src/stactools/global_mangrove_watch/commands.py
+++ b/src/stactools/global_mangrove_watch/commands.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional
 
 import click
 from click import Command, Group
@@ -34,16 +35,24 @@ def create_globalmangrovewatch_command(cli: Group) -> Command:
         collection.save_object()
 
     @globalmangrovewatch.command("create-item", short_help="Create a STAC item")
-    @click.argument("source")
+    @click.argument("cog_asset_href")
     @click.argument("destination")
-    def create_item_command(source: str, destination: str) -> None:
+    @click.option("--change-asset-href", type=str)
+    def create_item_command(
+        cog_asset_href: str, destination: str, change_asset_href: Optional[str] = None
+    ) -> None:
         """Creates a STAC Item
 
         Args:
-            source: HREF of the Asset associated with the Item
+            cog_asset_href: HREF of the COG asset associated with the Item
             destination: An HREF for the STAC Item
+            change_asset_href: Optional HREF to the change asset associated with the
+              Item
         """
-        item = stac.create_item(source)
+        item = stac.create_item(
+            cog_asset_href=cog_asset_href,
+            change_asset_href=change_asset_href,
+        )
         item.save_object(dest_href=destination)
 
     return globalmangrovewatch

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -5,6 +5,7 @@ from click.testing import CliRunner
 from pystac import Collection, Item
 
 from stactools.global_mangrove_watch.commands import create_globalmangrovewatch_command
+from stactools.global_mangrove_watch.constants import CHANGE_ASSET_NAME
 
 from . import test_data
 
@@ -12,10 +13,6 @@ command = create_globalmangrovewatch_command(Group())
 
 
 def test_create_collection(tmp_path: Path) -> None:
-    # Smoke test for the command line create-collection command
-    #
-    # Most checks should be done in test_stac.py::test_create_collection
-
     path = str(tmp_path / "collection.json")
     runner = CliRunner()
     result = runner.invoke(command, ["create-collection", path])
@@ -25,13 +22,27 @@ def test_create_collection(tmp_path: Path) -> None:
 
 
 def test_create_item(tmp_path: Path) -> None:
-    # Smoke test for the command line create-item command
-    #
-    # Most checks should be done in test_stac.py::test_create_item
     asset_href = test_data.get_path("data/GMW_N26W082_2020_v3.tif")
     path = str(tmp_path / "item.json")
     runner = CliRunner()
     result = runner.invoke(command, ["create-item", asset_href, path])
     assert result.exit_code == 0, "\n{}".format(result.output)
     item = Item.from_file(path)
+    assert not item.assets.get(CHANGE_ASSET_NAME)
+    item.validate()
+
+
+def test_create_item_with_change(tmp_path: Path) -> None:
+    asset_href = test_data.get_path("data/GMW_N26W082_2020_v3.tif")
+    change_asset_href = test_data.get_path("data/GMW_N26W082_chng_f1996_t2020_v3.tif")
+    path = str(tmp_path / "item.json")
+    runner = CliRunner()
+    result = runner.invoke(
+        command,
+        ["create-item", asset_href, path, "--change-asset-href", change_asset_href],
+    )
+    assert result.exit_code == 0, "\n{}".format(result.output)
+    item = Item.from_file(path)
+
+    assert item.assets.get(CHANGE_ASSET_NAME)
     item.validate()


### PR DESCRIPTION
The `create-item` CLI command would only accept the `cog_asset_href`, this adds the optional `change_asset_href`.
